### PR TITLE
Handle service-linked role ARN format

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -7,3 +7,5 @@
 - userIdentity.arn = who did it
 - need to handle assumed roles vs users
 - sts:AssumeRole changes the principal arn format
+
+- handle service-linked roles separately


### PR DESCRIPTION
Service-linked roles use a different ARN pattern. Added notes for implementation.